### PR TITLE
Ignore when max_line_length = off

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function editorConfigToPrettier(editorConfig) {
     result.tabWidth = editorConfig.tab_width;
   }
 
-  if (editorConfig.max_line_length) {
+  if (editorConfig.max_line_length && editorConfig.max_line_length !== "off") {
     result.printWidth = editorConfig.max_line_length;
   }
 

--- a/test.js
+++ b/test.js
@@ -91,3 +91,13 @@ assert.deepStrictEqual(
     singleQuote: false
   }
 );
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    quote_type: "double",
+    max_line_length: "off"
+  }),
+  {
+    singleQuote: false
+  }
+);


### PR DESCRIPTION
A valid value of `max_line_length` is `"off"` and we're setting `printWidth` to `"off"` and we should simply ignore the editorConfig setting.

This raised the issue https://github.com/prettier/prettier/issues/3410