### PR TITLE
[WIP] Convert .editorconfig’s end_of_line option to Prettier’s eol option

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function editorConfigToPrettier(editorConfig) {
   }
 
   if (["cr", "crlf", "lf"].indexOf(editorConfig.end_of_line) !== -1) {
-    result.eol = editorConfig.end_of_line;
+    result.endOfLine = editorConfig.end_of_line;
   }
 
   return result;

--- a/index.js
+++ b/index.js
@@ -37,5 +37,9 @@ function editorConfigToPrettier(editorConfig) {
     result.singleQuote = false;
   }
 
+  if (["cr", "crlf", "lf"].indexOf(editorConfig.end_of_line) !== -1) {
+    result.eol = editorConfig.end_of_line;
+  }
+
   return result;
 }

--- a/test.js
+++ b/test.js
@@ -102,5 +102,39 @@ assert.deepStrictEqual(
   }
 );
 
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    end_of_line: "cr"
+  }),
+  {
+    eol: "cr"
+  }
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    end_of_line: "crlf"
+  }),
+  {
+    eol: "crlf"
+  }
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    end_of_line: "lf"
+  }),
+  {
+    eol: "lf"
+  }
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    end_of_line: 123
+  }),
+  {}
+);
+
 assert.deepStrictEqual(editorconfigToPrettier({}), null);
 assert.deepStrictEqual(editorconfigToPrettier(null), null);

--- a/test.js
+++ b/test.js
@@ -107,7 +107,7 @@ assert.deepStrictEqual(
     end_of_line: "cr"
   }),
   {
-    eol: "cr"
+    endOfLine: "cr"
   }
 );
 
@@ -116,7 +116,7 @@ assert.deepStrictEqual(
     end_of_line: "crlf"
   }),
   {
-    eol: "crlf"
+    endOfLine: "crlf"
   }
 );
 
@@ -125,13 +125,13 @@ assert.deepStrictEqual(
     end_of_line: "lf"
   }),
   {
-    eol: "lf"
+    endOfLine: "lf"
   }
 );
 
 assert.deepStrictEqual(
   editorconfigToPrettier({
-    end_of_line: 123
+    endOfLine: 123
   }),
   {}
 );


### PR DESCRIPTION
Partially addresses https://github.com/prettier/prettier/issues/5320. Helps implement https://github.com/prettier/prettier/pull/5327.