### PR TITLE
Ignore "unset" values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,26 @@
 module.exports = editorConfigToPrettier;
 
+function removeUnset(editorConfig) {
+  const result = {};
+  const keys = Object.keys(editorConfig);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (editorConfig[key] === "unset") {
+      continue;
+    }
+    result[key] = editorConfig[key];
+  }
+  return result;
+}
+
 function editorConfigToPrettier(editorConfig) {
-  if (!editorConfig || Object.keys(editorConfig).length === 0) {
+  if (!editorConfig) {
+    return null;
+  }
+
+  editorConfig = removeUnset(editorConfig);
+
+  if (Object.keys(editorConfig).length === 0) {
     return null;
   }
 

--- a/test.js
+++ b/test.js
@@ -46,12 +46,13 @@ assert.deepStrictEqual(
 
 assert.deepStrictEqual(
   editorconfigToPrettier({
-    tab_width: 4,
-    indent_size: "tab"
+    indent_style: "space",
+    indent_size: 2,
+    max_line_length: "unset"
   }),
   {
-    tabWidth: 4,
-    useTabs: true
+    useTabs: false,
+    tabWidth: 2
   }
 );
 
@@ -132,6 +133,22 @@ assert.deepStrictEqual(
 assert.deepStrictEqual(
   editorconfigToPrettier({
     endOfLine: 123
+  }),
+  {}
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    useTabs: false,
+    tabWidth: "unset"
+  }),
+  {}
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({
+    useTabs: false,
+    tabWidth: "unset"
   }),
   {}
 );


### PR DESCRIPTION
This PR adds support for ignoring `"unset"` values.

See https://github.com/prettier/prettier/issues/5351