### PR TITLE
Map `insert_final_newline` to `insertFinalNewline`

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,5 +60,9 @@ function editorConfigToPrettier(editorConfig) {
     result.endOfLine = editorConfig.end_of_line;
   }
 
+  if (editorConfig.insert_final_newline === false) {
+    result.insertFinalNewline = editorConfig.insert_final_newline;
+  }
+
   return result;
 }

--- a/index.js
+++ b/index.js
@@ -60,7 +60,10 @@ function editorConfigToPrettier(editorConfig) {
     result.endOfLine = editorConfig.end_of_line;
   }
 
-  if (editorConfig.insert_final_newline === false) {
+  if (
+    editorConfig.insert_final_newline === false ||
+    editorConfig.insert_final_newline === true
+  ) {
     result.insertFinalNewline = editorConfig.insert_final_newline;
   }
 

--- a/test.js
+++ b/test.js
@@ -158,8 +158,12 @@ assert.deepStrictEqual(
   {}
 );
 
+assert.deepStrictEqual(editorconfigToPrettier({ insert_final_newline: true }), {
+  insertFinalNewline: true
+});
+
 assert.deepStrictEqual(
-  editorconfigToPrettier({ insert_final_newline: true }),
+  editorconfigToPrettier({ insert_final_newline: "true" }),
   {}
 );
 

--- a/test.js
+++ b/test.js
@@ -153,19 +153,9 @@ assert.deepStrictEqual(
   { insertFinalNewline: false }
 );
 
-assert.deepStrictEqual(
-  editorconfigToPrettier({ insert_final_newline: "false" }),
-  {}
-);
-
 assert.deepStrictEqual(editorconfigToPrettier({ insert_final_newline: true }), {
   insertFinalNewline: true
 });
-
-assert.deepStrictEqual(
-  editorconfigToPrettier({ insert_final_newline: "true" }),
-  {}
-);
 
 assert.deepStrictEqual(editorconfigToPrettier({}), null);
 assert.deepStrictEqual(editorconfigToPrettier(null), null);

--- a/test.js
+++ b/test.js
@@ -148,5 +148,20 @@ assert.deepStrictEqual(
   }
 );
 
+assert.deepStrictEqual(
+  editorconfigToPrettier({ insert_final_newline: false }),
+  { insertFinalNewline: false }
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({ insert_final_newline: "false" }),
+  {}
+);
+
+assert.deepStrictEqual(
+  editorconfigToPrettier({ insert_final_newline: true }),
+  {}
+);
+
 assert.deepStrictEqual(editorconfigToPrettier({}), null);
 assert.deepStrictEqual(editorconfigToPrettier(null), null);


### PR DESCRIPTION
## Description

This PR proposes to read editorconfig's `insert_final_newline` when it is set to `false`.

## Motivation

I know this PR might sound odd. Because Prettier follows unix guideline regarding the final newline ([Prettier doc reference](https://prettier.io/docs/en/rationale.html#empty-lines)).

Yet, handlebars / glimmer does not follow this standard ([see reference here](https://github.com/prettier/prettier/pull/6243#issuecomment-506720622)) because it would insert empty nodes at the bottom of the component's file.

So for now Prettier respects this handlebars choice and remove the final newline. But this is somehow inconsistent with other languages and it creates discussion / lack of understanding etc. One possibility could be to respect instead the user choice made with `.editorconfig`'s `insert_final_newline` option. Hence this PR.

In a follow-up, we'd use that `insertFinalNewline` option in handlebars printer to insert or remove the final newline.

## Links

- a closed (unmerged) PR to [add newlines at the end of handlebars files](https://github.com/prettier/prettier/pull/6243)