### PR TITLE
Interpret `max_line_length=off` as `printWidth: Number.POSITIVE_INFINITY`

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,12 @@ function editorConfigToPrettier(editorConfig) {
     result.tabWidth = editorConfig.tab_width;
   }
 
-  if (editorConfig.max_line_length && editorConfig.max_line_length !== "off") {
-    result.printWidth = editorConfig.max_line_length;
+  if (editorConfig.max_line_length) {
+    if (editorConfig.max_line_length === "off") {
+      result.printWidth = Number.POSITIVE_INFINITY;
+    } else {
+      result.printWidth = editorConfig.max_line_length;
+    }
   }
 
   if (editorConfig.quote_type === "single") {

--- a/test.js
+++ b/test.js
@@ -98,6 +98,7 @@ assert.deepStrictEqual(
     max_line_length: "off"
   }),
   {
+    printWidth: Number.POSITIVE_INFINITY,
     singleQuote: false
   }
 );


### PR DESCRIPTION
This fixes https://github.com/josephfrazier/editorconfig-to-prettier/issues/7, see https://github.com/prettier/prettier/issues/14514 for more context:

> **TL;DR: Should `max_line_length=off` in `.editorconfig` get interpreted as `printWidth: Number.MAX_SAFE_INTEGER`, or should we continue ignoring it, or something else?**
>
> Hey everyone, I'm the maintainer of [editorconfig-to-prettier](https://www.npmjs.com/package/editorconfig-to-prettier), which [Prettier uses](https://github.com/prettier/prettier/blob/5446a8f32a2717762c4d7a1bd5fe2615d76ebec7/src/config/resolve-config-editorconfig.js#L6) to convert [EditorConfig](https://editorconfig.org/) configuration to Prettier configuration.
>
> Over 5 years ago, bug #3410 was reported regarding the handling of `max_line_length=off`, and resulted in @duailibe [fixing `editorconfig-to-prettier` to ignore `max_line_length=off` in `.editorconfig` files](https://github.com/josephfrazier/editorconfig-to-prettier/pull/3) (the corresponding dependency version bump can be found [here](https://github.com/prettier/prettier/pull/3412)).
>
> However, there's been some [renewed interest](https://github.com/josephfrazier/editorconfig-to-prettier/issues/7#issuecomment-1468787319) from @celluj34 in having Prettier interpret `max_line_length=off` to mean e.g. `printWidth: A_REALLY_BIG_NUMBER` like [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
>
> My question is, would this cause unintended consequences? For example, would Prettier attempt to generate very long lines for files where `max_line_length=off`? I see that https://prettier.io/docs/en/options.html#print-width says:
>
> > In other words, don’t try to use printWidth as if it was ESLint’s [max-len](https://eslint.org/docs/rules/max-len) – they’re not the same. max-len just says what the maximum allowed line length is, but not what the generally preferred length is – which is what printWidth specifies.
>
> but I wonder if it would be ok in practice. I took a quick look at [the playground with `--print-width` set to 9999](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAzArlMMCW0AEAEnADYkQDqEATiQCYAUwA5tXHLlM-gLz4A6IABalyggDT5W7eHV74A5IKq06ghZIDOOEghjzUAQxKa4k6AFkI6UwHkAbnGriAvgEp8wflG-58OVAYAQmkOHC43YDYYdGoofCh0MhcAbm9fPz8Aeiz8ABVbABFbJHxC6AV9Gzh8akMoOggAW394tganDN19RJa+C0MYIQA6VHIafAYBoeG6huaGDwAqfABGAFEAagB2N2GYCABlGGpw5kXZuAAHEkMwOAYs-n5h57pNrJxmSUFBN3T4rUOLF4gAeOg4ez4MC3TSaAByhiacB4CmIZEoNHoCnwuBguh4wAABgBNaz4QxsfD2HDaA7UBLoJoAIyc+AAJMBGS0XESXPhLNY7I5qITBdUHE4XAA+AGZfCgzQnaDMaVc0KcZjDTQkHD3Bj4AAMklW+D2BwAqlcrk4AMKGUyLfCbKRsMJcbW6-Wrc0QAAyEAA7naHQ8PC5QVkldQVbLAX4WG7NcMEHRNBQcEMGBI-vgAPwCECF-ClRVXer4JUATwJwGAkHI1FKSn40irChcMokhcjmnLUGl+BcGT8oLgTTj-Bg6qTcDkw58MEj47j8q5DG0ulg-3jmQLgleIBHmVKgiCggXx8jEPs0rSPigLhA4hAECuuGgmmQoEpMcDAAVKQQL8UGMQNDCrL8X2ZOowAAaw4Q4kTgP1wjgZAjBMMwQBgu4EJgQ5yzAM5kBOdBsPHVk6DoOc-XqZh0EMZg4AAMRoJpBk1ZAQEMdADmfYQYCaEgKCETM4D7O44EOYDM0hTMq24sA4QE8JTGoGB-zqZgOIw4xTBfAArTQAA9DjOXQAEV0AgeA9Kwl9y2odTuOZQxWRIASrhjUwKDqK5uO8iSnEcASAEcbPgLS3xAnjNAAWigdgaLoAS2AinA2C0pjdKQTCDJAUwmhwUjqHIl9tC4XQAEEYBOHBmT4uB-ycVCkvsgrKuYKzIvQvL9OwmB3IzOghmQAAmF8TkMHQzltZpcpACSAFYBOqPJ3JA-LsPsciAEkOlgQ4wFOd9qoaY4az67bHNOWARrGpAAE4XqezsgA), and the output seems reasonable-ish:
>
> ```js
> function HelloWorld({ greeting = "hello", greeted = '"World"', silent = false, onMouseOver }) {
>   if (!greeting) {
>     return null;
>   }
>
>   // TODO: Don't use random in render
>   let num = Math.floor(Math.random() * 1e7)
>     .toString()
>     .replace(/\.\d+/gi, "");
>
>   return (
>     <div className="HelloWorld" title={`You are visitor number ${num}`} onMouseOver={onMouseOver}>
>       <strong>{greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}</strong>
>       {greeting.endsWith(",") ? " " : <span style={{ color: "grey" }}>", "</span>}
>       <em>{greeted}</em>
>       {silent ? "." : "!"}
>     </div>
>   );
> }
> ```
>
> Part of me thinks that if someone is explicitly putting `max_line_length=off` in their `.editorconfig`, then they should be ok with this formatting. On the other hand, I haven't really used Prettier for a while now, and I'm not very familiar with the variety of use cases people have for it, so I thought I'd ask here.
>
> What do you think? Should `max_line_length=off` in `.editorconfig` get interpreted as `printWidth: Number.MAX_SAFE_INTEGER`, or should we continue ignoring it, or something else?
>
> Thanks!

> It make sense to support it. Let's parse it as `Infinity`.
>
> https://github.com/prettier/prettier/blob/5446a8f32a2717762c4d7a1bd5fe2615d76ebec7/src/language-js/print/template-literal.js#L55

> Oh, thanks for pointing that out, [we're already using a "really big number" in a handful of places](https://github.com/search?q=repo%3Aprettier%2Fprettier+%22printwidth%3A+number%22&type=code).
> 
> I'll probably wait on some other maintainers to chime in before making any changes in my package, but I appreciate the feedback 👍🏻

> I think we can also improve the doc printer by skipping this check if `printWidth` is `Infinity`.
> 
> https://github.com/prettier/prettier/blob/5446a8f32a2717762c4d7a1bd5fe2615d76ebec7/src/document/doc-printer.js#L162

> > I'll probably wait on some other maintainers to chime in before making any changes in my package, but I appreciate the feedback 👍🏻
> 
> Oh lol, I see now that you're the primary contributor nowadays ([this year so far](https://github.com/prettier/prettier/graphs/contributors?from=2023-01-01&to=2023-03-15&type=c))
> 
> I'd be happy to publish a new version of `editorconfig-to-prettier` that converts `max_line_length=off` to `printWidth: Number.POSITIVE_INFINITY`, but I'm not sure if I can help out with the adding tests/optimizations here in the Prettier repo (but I might try!). How does that sound?