### PR TITLE
Don't test Node v14, it's flaky and almost EOL

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
The GitHub action run likes to fail with:

    Cache folder path is retrieved for npm but doesn't exist on disk: /home/runner/.npm

For example, see https://github.com/josephfrazier/editorconfig-to-prettier/actions/runs/4437129925/jobs/7786423216

Also, Node.js v14 will reach its end-of-life in a little over a month,
on 2023-04-30, see https://github.com/nodejs/release#release-schedule